### PR TITLE
fix: safely get error message when catch error

### DIFF
--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -164,7 +164,7 @@ export class PromisePoolExecutor<T> {
       })
       .catch(error => {
         this.errors.push(
-          new PromisePoolError(error.message, item)
+          new PromisePoolError(this.getErrorMsg(error), item)
         )
       })
 
@@ -231,5 +231,22 @@ export class PromisePoolExecutor<T> {
    */
   activeCount (): number {
     return this.tasks.length
+  }
+
+  /**
+   * Returns the message of error
+   *
+   * @returns {String}
+   */
+  private getErrorMsg (error: any): string {
+    if (error instanceof Error) {
+      return error.message
+    }
+
+    if (typeof error === 'string' || typeof error === 'number') {
+      return error.toString()
+    }
+
+    return ''
   }
 }

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -165,8 +165,24 @@ describe('Promise Pool', () => {
   //         return id
   //       })
 
-//     expect(false).toBe(true) // should not be reached
-//   } catch (error) {
-//     const err = new Error('Oh no, not a 3.')
-//     expect(error).toEqual(err)
+  //     expect(false).toBe(true) // should not be reached
+  //   } catch (error) {
+  //     const err = new Error('Oh no, not a 3.')
+  //     expect(error).toEqual(err)
+
+  it('promise reject with nothing', async () => {
+    const ids = [1, 2, 3, 4, 5]
+
+    const { errors } = await PromisePool
+      .withConcurrency(2)
+      .for(ids)
+      .process(async id => {
+        await new Promise((resolve, reject) => setTimeout(reject, 10))
+
+        return id
+      })
+
+    expect(errors.length).toEqual(ids.length)
+    expect(errors).toSatisfyAll(error => error.message === '')
+  })
 })


### PR DESCRIPTION
Safely get error message when the caught error is not instance of `Error`, so that error can be successfully collected