### PR TITLE
feat: add `onError` operator - #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ await PromisePool
   })
 ```
 
+The promise pool allows for custom error handling:
+
+```js
+await PromisePool
+  .for(users)
+  .onError(async (error, user) => {
+    if (error instanceof ThrottleError) { // Execute error handling on specific errors
+      await retryUser(user)
+
+      return
+    }
+
+    throw error // Uncaught errors will immediately stop PromisePool
+  })
+  .process(async data => {
+    // processes 10 items in parallel by default
+  })
+```
+
 
 ## Contributing
 


### PR DESCRIPTION
As discussed in #3, this PR adds the `onError` operator to `promise-pool`.

This PR changes the following:

- Add `onError` operator
- Document class members and methods
- Add tests to validate behavior
- Update official documentation

Any feedback is welcome.