### PR TITLE
add: iterator support and yarn.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist
 node_modules
 npm-debug.log
 package-lock.json
+yarn.lock
 
 # code coverage folder
 coverage

--- a/examples/promise-pool.js
+++ b/examples/promise-pool.js
@@ -22,11 +22,11 @@ async function run () {
   const { results, errors } = await PromisePool
     .for(timeouts)
     .withConcurrency(2)
-    .process(async (timeout) => {
+    .process(async (timeout, i) => {
       await new Promise(resolve => setTimeout(resolve, timeout))
-      console.log(`waited ${timeout}ms`)
+      console.log(`${i} waited ${timeout}ms`)
 
-      return timeout
+      return [timeout, i]
     })
 
   console.log('Results ->')

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -27,7 +27,7 @@ export class PromisePoolExecutor<T, R> {
   /**
    * The async processing function receiving each item from the `items` array.
    */
-  private handler: (item: T, i: string) => any
+  private handler: (item: T, i: number) => any
 
   /**
    * The async error handling function.
@@ -85,7 +85,7 @@ export class PromisePoolExecutor<T, R> {
    *
    * @returns {PromisePoolExecutor}
    */
-  withHandler (action: (item: T, i: string) => R | Promise<R>): this {
+  withHandler (action: (item: T, i: number) => R | Promise<R>): this {
     this.handler = action
 
     return this
@@ -169,7 +169,7 @@ export class PromisePoolExecutor<T, R> {
    * @returns {Promise}
    */
   async process (): Promise<ReturnValue<T, R>> {
-    for (const [i, item] of Object.entries(this.items)) {
+    for (const [i, item] of this.items.entries()) {
       if (this.hasReachedConcurrencyLimit()) {
         await this.processingSlot()
       }
@@ -202,7 +202,7 @@ export class PromisePoolExecutor<T, R> {
    *
    * @param {*} item
    */
-  startProcessing (item: T, i: string): void {
+  startProcessing (item: T, i: number): void {
     const task = this.createTaskFor(item, i)
       .then(result => {
         this.results.push(result)
@@ -230,7 +230,7 @@ export class PromisePoolExecutor<T, R> {
    *
    * @returns {*}
    */
-  async createTaskFor (item: T, i: string): Promise<any> {
+  async createTaskFor (item: T, i: number): Promise<any> {
     return this.handler(item, i)
   }
 

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -27,7 +27,7 @@ export class PromisePoolExecutor<T, R> {
   /**
    * The async processing function receiving each item from the `items` array.
    */
-  private handler: (item: T) => any
+  private handler: (item: T, i: string) => any
 
   /**
    * The async error handling function.
@@ -85,7 +85,7 @@ export class PromisePoolExecutor<T, R> {
    *
    * @returns {PromisePoolExecutor}
    */
-  withHandler (action: (item: T) => R | Promise<R>): this {
+  withHandler (action: (item: T, i: string) => R | Promise<R>): this {
     this.handler = action
 
     return this
@@ -169,12 +169,12 @@ export class PromisePoolExecutor<T, R> {
    * @returns {Promise}
    */
   async process (): Promise<ReturnValue<T, R>> {
-    for (const item of this.items) {
+    for (const [i, item] of Object.entries(this.items)) {
       if (this.hasReachedConcurrencyLimit()) {
         await this.processingSlot()
       }
 
-      this.startProcessing(item)
+      this.startProcessing(item, i)
     }
 
     return await this.drained()
@@ -202,8 +202,8 @@ export class PromisePoolExecutor<T, R> {
    *
    * @param {*} item
    */
-  startProcessing (item: T): void {
-    const task = this.createTaskFor(item)
+  startProcessing (item: T, i: string): void {
+    const task = this.createTaskFor(item, i)
       .then(result => {
         this.results.push(result)
         this.tasks.splice(this.tasks.indexOf(task), 1)
@@ -230,8 +230,8 @@ export class PromisePoolExecutor<T, R> {
    *
    * @returns {*}
    */
-  async createTaskFor (item: T): Promise<any> {
-    return this.handler(item)
+  async createTaskFor (item: T, i: string): Promise<any> {
+    return this.handler(item, i)
   }
 
   /**

--- a/src/promise-pool.ts
+++ b/src/promise-pool.ts
@@ -97,7 +97,7 @@ export class PromisePool<T> {
    *
    * @returns Promise<{ results, errors }>
    */
-  async process<R> (callback: (item: T, i: string) => R | Promise<R>): Promise<ReturnValue<T, R>> {
+  async process<R> (callback: (item: T, i: number) => R | Promise<R>): Promise<ReturnValue<T, R>> {
     return new PromisePoolExecutor<T, R>()
       .withConcurrency(this.concurrency)
       .withHandler(callback)

--- a/src/promise-pool.ts
+++ b/src/promise-pool.ts
@@ -97,7 +97,7 @@ export class PromisePool<T> {
    *
    * @returns Promise<{ results, errors }>
    */
-  async process<R> (callback: (item: T) => R | Promise<R>): Promise<ReturnValue<T, R>> {
+  async process<R> (callback: (item: T, i: string) => R | Promise<R>): Promise<ReturnValue<T, R>> {
     return new PromisePoolExecutor<T, R>()
       .withConcurrency(this.concurrency)
       .withHandler(callback)

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -308,4 +308,18 @@ describe('Promise Pool', () => {
 
     expect(errors).toSatisfyAll(error => error.message === 'failed')
   })
+
+  it('returns the iterator', async () => {
+    const ids = [1, 2, 3, 4, 5]
+
+    const { results } = await PromisePool
+      .withConcurrency(3000)
+      .for(ids)
+      .process(async (timeout, i) => {
+        await pause(timeout)
+        return [timeout, i]
+      })
+
+    expect(results).toEqual([[1, 0], [2, 1], [3, 2], [4, 3], [5, 4]])
+  })
 })


### PR DESCRIPTION
Pretty much as the title says added iterator support and added yarn.lock to the .gitignore.

Result of examples/promise-pool.js
```
1 waited 200ms
0 waited 800ms
3 waited 100ms
2 waited 700ms
4 waited 400ms
6 waited 600ms
5 waited 1000ms
7 waited 500ms
9 waited 300ms
8 waited 900ms
Results ->
[
  [ 200, '1' ],  [ 800, '0' ],
  [ 100, '3' ],  [ 700, '2' ],
  [ 400, '4' ],  [ 600, '6' ],
  [ 1000, '5' ], [ 500, '7' ],
  [ 300, '9' ],  [ 900, '8' ]
]
Errors -> none
```

Test results (Basically the same as the original):
```
--------------------------|---------|----------|---------|---------|-------------------
File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------------|---------|----------|---------|---------|-------------------
All files                 |     100 |      100 |   96.55 |     100 | 
 index.js                 |     100 |      100 |     100 |     100 | 
 promise-pool-error.js    |     100 |      100 |     100 |     100 | 
 promise-pool-executor.js |     100 |      100 |   94.73 |     100 | 
 promise-pool.js          |     100 |      100 |     100 |     100 | 
--------------------------|---------|----------|---------|---------|-------------------
Test Suites: 1 failed, 1 total
Tests:       1 failed, 20 passed, 21 total
Snapshots:   0 total
Time:        2.139 s, estimated 4 s
Ran all test suites.
```