### PR TITLE
fix build failure for TS consumers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,4 @@
 
 import { PromisePool } from './promise-pool'
 
-export = PromisePool
+export { PromisePool }

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const expect = require('expect')
-const PromisePool = require('../dist')
+const { PromisePool } = require('../dist')
 const { test } = require('uvu')
 
 const pause = timeout => new Promise(resolve => setTimeout(resolve, timeout))

--- a/test/stop-the-pool.js
+++ b/test/stop-the-pool.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const expect = require('expect')
-const PromisePool = require('../dist')
+const { PromisePool } = require('../dist')
 const { test } = require('uvu')
 
 const pause = timeout => new Promise(resolve => setTimeout(resolve, timeout))


### PR DESCRIPTION
Before this commit, Typescript consumers would get the following error:
"This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export"
consumers of this library would have to set `esModuleInterop` to true in
their `tsconfig.json` in order to build with this library.

With this commit, consumers can simply import without adding
`esModuleInterop` to their configuration.

Examples:
``` Typescript
// ES6:
import { PromisePool } from '@supercharge/promise-pool'

// ES5:
const { PromisePool } = require('@supercharge/promise-pool')
```

Closes: #38

@marcuspoehls Let me know what you think, Thank you!