### PR TITLE
the results array corresponds to the input array in size and order

### DIFF
--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -39,7 +39,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
     /**
      * The list of results.
      */
-    readonly results: R[]
+    results: R[]
 
     /**
      * The list of errors.
@@ -133,6 +133,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
    */
   for (items: T[]): this {
     this.meta.items = items
+    this.meta.results = Array(items.length).fill(undefined)
 
     return this
   }
@@ -417,7 +418,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
   startProcessing (item: T, index: number): void {
     const task: Promise<void> = this.createTaskFor(item, index)
       .then(result => {
-        this.save(result).removeActive(task)
+        this.save(result, index).removeActive(task)
       })
       .catch(async error => {
         await this.handleErrorFor(error, item)
@@ -448,11 +449,12 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
    * Save the given calculation `result`.
    *
    * @param {*} result
+   * @param {number} index
    *
    * @returns {PromisePoolExecutor}
    */
-  save (result: any): this {
-    this.results().push(result)
+  save (result: any, index: number): this {
+    this.results()[index] = result
 
     return this
   }

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -39,7 +39,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
     /**
      * The list of results.
      */
-    results: R[]
+    readonly results: R[]
 
     /**
      * The list of errors.
@@ -133,7 +133,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
    */
   for (items: T[]): this {
     this.meta.items = items
-    this.meta.results = Array(items.length).fill(undefined)
+    this.meta.results.splice(0, 0, ...Array(items.length).fill(undefined))
 
     return this
   }

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -86,7 +86,7 @@ test('concurrency: 2', async () => {
     })
 
   expect(errors).toEqual([])
-  expect(results).toEqual([100, 200, 400, 100, 300])
+  expect(results).toEqual([400, 100, 200, 300, 100])
 
   const elapsed = Date.now() - start
 
@@ -116,7 +116,7 @@ test('ensures concurrency', async () => {
       return timeout
     })
 
-  expect(results).toEqual([20, 30, 10, 10, 10, 100, 50])
+  expect(results).toEqual([100, 20, 30, 10, 10, 10, 50])
 
   const elapsed = Date.now() - start
 
@@ -152,7 +152,7 @@ test('returns errors', async () => {
       return id
     })
 
-  expect(results).toEqual([1, 2, 4])
+  expect(results).toEqual([1, 2, undefined, 4])
 
   expect(errors.length).toEqual(1)
   expect(errors[0].item).toEqual(3)
@@ -203,7 +203,7 @@ test('keeps processing with when errors occur', async () => {
       return id
     })
 
-  expect(results).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10])
+  expect(results).toEqual([undefined, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
   expect(errors.length).toEqual(1)
   expect(
@@ -245,7 +245,7 @@ test('should handle error and continue processing', async () => {
     })
 
   expect(errors).toEqual([])
-  expect(results).toEqual([1, 2, 4])
+  expect(results).toEqual([1, 2, undefined, 4])
   expect(collectedItemsOnError).toEqual([3])
 })
 
@@ -538,6 +538,17 @@ test('fails to change the concurrency for a running pool to an invalid value', a
         await pause(timeout)
       })
   ).rejects.toThrow(ValidationError)
+})
+
+test('the order of results matches the order of inputs', async () => {
+  const timeouts = [20, 10]
+  const { results } = await PromisePool
+    .for(timeouts)
+    .process(async timeout => {
+      await pause(timeout)
+      return timeout
+    })
+  expect(results).toEqual([20, 10])
 })
 
 test.run()

--- a/test/stop-the-pool.js
+++ b/test/stop-the-pool.js
@@ -80,7 +80,7 @@ test('stops the pool from async error handler', async () => {
       return timeout
     })
 
-  expect(results).toEqual([30])
+  expect(results).toEqual([undefined, undefined, 30, undefined, undefined])
 })
 
 test.run()


### PR DESCRIPTION
PR for #26

I think the way it works with this PR is the expected behavior for new users of the library, but you might consider updating the doc to point out the change for users of past versions.