### PR TITLE
Use corresponding results 2

### DIFF
--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -144,7 +144,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
   for (items: T[]): this {
     this.meta.items = items
     if (this.meta.shouldResultsCorrespond) {
-      this.meta.results.splice(0, 0, ...Array(items.length).fill(undefined))
+      this.meta.results.splice(0, 0, ...Array(items.length).fill(PromisePool.notRun))
     }
 
     return this

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -42,7 +42,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
     /**
      * The list of results.
      */
-    readonly results: R[]
+    readonly results: Array<R | Symbol>
 
     /**
      * The list of errors.
@@ -227,7 +227,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
    *
    * @returns {R[]}
    */
-  results (): any[] {
+  results (): Array<R | Symbol> {
     return this.meta.results
   }
 

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -1,6 +1,6 @@
 'use strict'
 
-import { ReturnValue } from './return-value'
+import { ReturnValue, Result } from './return-value'
 import { PromisePool } from './promise-pool'
 import { PromisePoolError } from './promise-pool-error'
 import { StopThePromisePoolError } from './stop-the-promise-pool-error'
@@ -42,7 +42,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
     /**
      * The list of results.
      */
-    readonly results: Array<R | Symbol>
+    readonly results: Array<Result<R>>
 
     /**
      * The list of errors.
@@ -227,7 +227,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
    *
    * @returns {R[]}
    */
-  results (): Array<R | Symbol> {
+  results (): Array<Result<R>> {
     return this.meta.results
   }
 

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -1,6 +1,7 @@
 'use strict'
 
 import { ReturnValue } from './return-value'
+import { PromisePool } from './promise-pool'
 import { PromisePoolError } from './promise-pool-error'
 import { StopThePromisePoolError } from './stop-the-promise-pool-error'
 import { ErrorHandler, ProcessHandler, OnProgressCallback, Statistics, Stoppable, UsesConcurrency } from './contracts'
@@ -25,6 +26,8 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
      * The number of concurrently running tasks.
      */
     concurrency: number
+
+    shouldResultsCorrespond: boolean
 
     /**
      * Determine whether the pool is stopped.
@@ -78,6 +81,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
       results: [],
       stopped: false,
       concurrency: 10,
+      shouldResultsCorrespond: false,
       processedItems: [],
     }
 
@@ -124,6 +128,12 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
     return this.meta.concurrency
   }
 
+  useCorrespondingResults (shouldResultsCorrespond: boolean): this {
+    this.meta.shouldResultsCorrespond = shouldResultsCorrespond
+
+    return this
+  }
+
   /**
    * Set the items to be processed in the promise pool.
    *
@@ -133,6 +143,9 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
    */
   for (items: T[]): this {
     this.meta.items = items
+    if (this.meta.shouldResultsCorrespond) {
+      this.meta.results.splice(0, 0, ...Array(items.length).fill(undefined))
+    }
 
     return this
   }
@@ -214,7 +227,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
    *
    * @returns {R[]}
    */
-  results (): R[] {
+  results (): any[] {
     return this.meta.results
   }
 
@@ -417,10 +430,10 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
   startProcessing (item: T, index: number): void {
     const task: Promise<void> = this.createTaskFor(item, index)
       .then(result => {
-        this.save(result).removeActive(task)
+        this.save(result, index).removeActive(task)
       })
       .catch(async error => {
-        await this.handleErrorFor(error, item)
+        await this.handleErrorFor(error, item, index)
         this.removeActive(task)
       })
       .finally(() => {
@@ -448,11 +461,16 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
    * Save the given calculation `result`.
    *
    * @param {*} result
+   * @param {number} index
    *
    * @returns {PromisePoolExecutor}
    */
-  save (result: any): this {
-    this.results().push(result)
+  save (result: any, index: number): this {
+    if (this.meta.shouldResultsCorrespond) {
+      this.results()[index] = result
+    } else {
+      this.results().push(result)
+    }
 
     return this
   }
@@ -475,8 +493,13 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
    *
    * @param {Error} error
    * @param {T} item
+   * @param {number} index
    */
-  async handleErrorFor (error: Error, item: T): Promise<void> {
+  async handleErrorFor (error: Error, item: T, index: number): Promise<void> {
+    if (this.meta.shouldResultsCorrespond) {
+      this.results()[index] = PromisePool.rejected
+    }
+
     if (this.isStoppingThePoolError(error)) {
       return
     }

--- a/src/promise-pool.ts
+++ b/src/promise-pool.ts
@@ -15,6 +15,8 @@ export class PromisePool<T> {
    */
   private concurrency: number
 
+  private shouldResultsCorrespond: boolean
+
   /**
    * The error handler callback function
    */
@@ -30,6 +32,8 @@ export class PromisePool<T> {
    */
   private readonly onTaskFinishedHandlers: Array<OnProgressCallback<T>>
 
+  public static readonly rejected: Symbol = Symbol('rejected')
+
   /**
    * Instantiates a new promise pool with a default `concurrency: 10` and `items: []`.
    *
@@ -37,6 +41,7 @@ export class PromisePool<T> {
    */
   constructor (items?: T[]) {
     this.concurrency = 10
+    this.shouldResultsCorrespond = false
     this.items = items ?? []
     this.errorHandler = undefined
     this.onTaskStartedHandlers = []
@@ -128,6 +133,12 @@ export class PromisePool<T> {
     return this
   }
 
+  useCorrespondingResults (): PromisePool<T> {
+    this.shouldResultsCorrespond = true
+
+    return this
+  }
+
   /**
    * Starts processing the promise pool by iterating over the items
    * and running each item through the async `callback` function.
@@ -139,6 +150,7 @@ export class PromisePool<T> {
   async process<ResultType, ErrorType = any> (callback: ProcessHandler<T, ResultType>): Promise<ReturnValue<T, ResultType, ErrorType>> {
     return new PromisePoolExecutor<T, ResultType>()
       .useConcurrency(this.concurrency)
+      .useCorrespondingResults(this.shouldResultsCorrespond)
       .withHandler(callback)
       .handleError(this.errorHandler)
       .onTaskStarted(this.onTaskStartedHandlers)

--- a/src/promise-pool.ts
+++ b/src/promise-pool.ts
@@ -32,6 +32,7 @@ export class PromisePool<T> {
    */
   private readonly onTaskFinishedHandlers: Array<OnProgressCallback<T>>
 
+  public static readonly notRun: Symbol = Symbol('notRun')
   public static readonly rejected: Symbol = Symbol('rejected')
 
   /**

--- a/src/return-value.ts
+++ b/src/return-value.ts
@@ -6,7 +6,7 @@ export interface ReturnValue<T, R, E = any> {
   /**
    * The list of results returned by the processing function.
    */
-  results: R[]
+  results: Array<R | Symbol>
 
   /**
    * The list of errors that occurred while processing all items in the pool.

--- a/src/return-value.ts
+++ b/src/return-value.ts
@@ -2,11 +2,13 @@
 
 import { PromisePoolError } from './promise-pool-error'
 
+export type Result<R> = R | Symbol
+
 export interface ReturnValue<T, R, E = any> {
   /**
    * The list of results returned by the processing function.
    */
-  results: Array<R | Symbol>
+  results: Array<Result<R>>
 
   /**
    * The list of errors that occurred while processing all items in the pool.

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,40 @@
+'use strict'
+
+import { PromisePool } from './promise-pool'
+import {expect} from "expect";
+
+async function pause (timeout: number) {
+  return new Promise(resolve => {
+    setTimeout(resolve, timeout)
+  })
+}
+
+async function go() {
+  const timeouts: number[] = [20, 0, 10, 100]
+
+  const output = await PromisePool<number, boolean>
+    .withConcurrency(1)
+    .for(timeouts)
+    .handleError((_error, _index, pool) => {
+      pool.stop()
+    })
+    // .useCorrespondingResults()
+    .process<number, string>(async (timeout): Promise<number> => {
+      if (timeout) {
+        await pause(timeout)
+        return timeout
+      }
+      throw new Error('did not work')
+    })
+
+  const results: number[] = output.results
+  // const results: (number | Symbol)[] = output.results
+
+  console.log('results[0]', results[0])
+  console.log('results[1]', results[1])
+  console.log('results[2]', results[2])
+  console.log('results[3]', results[3])
+  expect(results).toEqual([20, PromisePool.rejected, 10, PromisePool.notRun])
+}
+
+go()

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -557,4 +557,25 @@ test('useCorrespondingResults keeps results in order', async () => {
   expect(results).toEqual([20, PromisePool.rejected, 10])
 })
 
+test('useCorrespondingResults defaults results to notRun symbol', async () => {
+  const timeouts = [20, undefined, 10, 100]
+
+  const { results } = await PromisePool
+    .withConcurrency(1)
+    .for(timeouts)
+    .handleError((_error, _index, pool) => {
+      pool.stop()
+    })
+    .useCorrespondingResults()
+    .process(async (timeout) => {
+      if (timeout) {
+        await pause(timeout)
+        return timeout
+      }
+      throw new Error('did not work')
+    })
+
+  expect(results).toEqual([20, PromisePool.rejected, 10, PromisePool.notRun])
+})
+
 test.run()

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -540,4 +540,21 @@ test('fails to change the concurrency for a running pool to an invalid value', a
   ).rejects.toThrow(ValidationError)
 })
 
+test('useCorrespondingResults keeps results in order', async () => {
+  const timeouts = [20, undefined, 10]
+
+  const { results } = await PromisePool
+    .for(timeouts)
+    .useCorrespondingResults()
+    .process(async (timeout) => {
+      if (timeout) {
+        await pause(timeout)
+        return timeout
+      }
+      throw new Error('did not work')
+    })
+
+  expect(results).toEqual([20, PromisePool.rejected, 10])
+})
+
 test.run()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
   "exclude": [
     "./node_modules",
     "./test",
-    "./dist"
+    "./dist",
+    "./src/test.ts"
   ]
 }


### PR DESCRIPTION
Follow-up to #56

With this PR, I'm showing you what I attempted for your [comment in 56](https://github.com/supercharge/promise-pool/pull/57#issuecomment-1229914165), carrying the ReturnType.

The problem is this doesn't change enough. The tests pass but only because they are in JS. If you run the `src/test.ts` file (in the wrong dir, I know) with `ts-node`, you get:

```
$ npx ts-node src/test.ts 
/home/tylercollier/.npm/_npx/1bf7c3c15bf47d04/node_modules/ts-node/src/index.ts:859
    return new TSError(diagnosticText, diagnosticCodes, diagnostics);
           ^
TSError: ⨯ Unable to compile TypeScript:
src/test.ts:30:9 - error TS2322: Type 'Result<number>[]' is not assignable to type 'number[]'.
  Type 'Result<number>' is not assignable to type 'number'.
    Type 'Symbol' is not assignable to type 'number'.

30   const results: number[] = output.results
           ~~~~~~~

    at createTSError (/home/tylercollier/.npm/_npx/1bf7c3c15bf47d04/node_modules/ts-node/src/index.ts:859:12)
    at reportTSError (/home/tylercollier/.npm/_npx/1bf7c3c15bf47d04/node_modules/ts-node/src/index.ts:863:19)
    at getOutput (/home/tylercollier/.npm/_npx/1bf7c3c15bf47d04/node_modules/ts-node/src/index.ts:1077:36)
    at Object.compile (/home/tylercollier/.npm/_npx/1bf7c3c15bf47d04/node_modules/ts-node/src/index.ts:1433:41)
    at Module.m._compile (/home/tylercollier/.npm/_npx/1bf7c3c15bf47d04/node_modules/ts-node/src/index.ts:1617:30)
    at Module._extensions..js (internal/modules/cjs/loader.js:785:10)
    at Object.require.extensions.<computed> [as .ts] (/home/tylercollier/.npm/_npx/1bf7c3c15bf47d04/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (internal/modules/cjs/loader.js:641:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:837:10) {
  diagnosticCodes: [ 2322 ]
}
```

This is why I was suggesting a change will also need to be made to PromisePoolExecutor, which has `results` whose type is `R[]` and not `(R | Symbol)[]`. I was thinking of a base class that doesn't declare/use results, and 2 subclasses that do, one that uses `R[]` for results, and one that uses `(R | Symbol)[]`. This might not work, I didn't try it.

As a reminder, I had also changed the definition of `results` in `return-value.ts` from `R[]` to `Array<Result<R>>`, where `Result` was `R | Symbol`. To not be a breaking change, that probably needs to be changed back.