### PR TITLE
Refined types for corresponding results

### DIFF
--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -1,14 +1,11 @@
 'use strict'
 
 import { ReturnValue } from './return-value'
+import { CorrespondingResult, notRun, rejected } from './promise-pool'
 import { PromisePoolError } from './promise-pool-error'
 import { StopThePromisePoolError } from './stop-the-promise-pool-error'
 import { ErrorHandler, ProcessHandler, OnProgressCallback, Statistics, Stoppable, UsesConcurrency } from './contracts'
 import { ValidationError } from './validation-error'
-
-export const notRun: unique symbol = Symbol('notRun')
-export const rejected: unique symbol = Symbol('rejected')
-export type CorrespondingResult<R> = R | typeof notRun | typeof rejected
 
 export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, Statistics<T> {
   /**

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -7,7 +7,7 @@ import { StopThePromisePoolError } from './stop-the-promise-pool-error'
 import { ErrorHandler, ProcessHandler, OnProgressCallback, Statistics, Stoppable, UsesConcurrency } from './contracts'
 import { ValidationError } from './validation-error'
 
-type Result<R> = R | Symbol
+type Result<R> = R | symbol
 
 export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, Statistics<T> {
   /**

--- a/src/promise-pool.ts
+++ b/src/promise-pool.ts
@@ -1,8 +1,12 @@
 'use strict'
 
 import { ReturnValue } from './return-value'
-import { PromisePoolExecutor, CorrespondingResult } from './promise-pool-executor'
+import { PromisePoolExecutor } from './promise-pool-executor'
 import { ErrorHandler, ProcessHandler, OnProgressCallback } from './contracts'
+
+export const notRun: unique symbol = Symbol('notRun')
+export const rejected: unique symbol = Symbol('rejected')
+export type CorrespondingResult<R> = R | typeof notRun | typeof rejected
 
 export class PromisePool<T, UseCorrespondingResults = false> {
   /**

--- a/src/promise-pool.ts
+++ b/src/promise-pool.ts
@@ -56,7 +56,7 @@ export class PromisePool<T, UseCorrespondingResults = false> {
    *
    * @returns {PromisePool}
    */
-  withConcurrency (concurrency: number): PromisePool<T> {
+  withConcurrency (concurrency: number): PromisePool<T, UseCorrespondingResults> {
     this.concurrency = concurrency
 
     return this
@@ -80,8 +80,13 @@ export class PromisePool<T, UseCorrespondingResults = false> {
    *
    * @returns {PromisePool}
    */
-  for<T> (items: T[]): PromisePool<T> {
-    return new PromisePool<T>(items).withConcurrency(this.concurrency)
+  for<T> (items: T[]): PromisePool<T, UseCorrespondingResults> {
+    const promisePool = new PromisePool<T, UseCorrespondingResults>(items)
+      .withConcurrency(this.concurrency)
+    if (this.shouldResultsCorrespond) {
+      return promisePool.useCorrespondingResults()
+    }
+    return promisePool
   }
 
   /**
@@ -102,7 +107,7 @@ export class PromisePool<T, UseCorrespondingResults = false> {
    *
    * @returns {PromisePool}
    */
-  handleError (handler: ErrorHandler<T>): PromisePool<T> {
+  handleError (handler: ErrorHandler<T>): PromisePool<T, UseCorrespondingResults> {
     this.errorHandler = handler
 
     return this
@@ -115,7 +120,7 @@ export class PromisePool<T, UseCorrespondingResults = false> {
    *
    * @returns {PromisePool}
    */
-  onTaskStarted (handler: OnProgressCallback<T>): PromisePool<T> {
+  onTaskStarted (handler: OnProgressCallback<T>): PromisePool<T, UseCorrespondingResults> {
     this.onTaskStartedHandlers.push(handler)
 
     return this
@@ -128,7 +133,7 @@ export class PromisePool<T, UseCorrespondingResults = false> {
     *
     * @returns {PromisePool}
     */
-  onTaskFinished (handler: OnProgressCallback<T>): PromisePool<T> {
+  onTaskFinished (handler: OnProgressCallback<T>): PromisePool<T, UseCorrespondingResults> {
     this.onTaskFinishedHandlers.push(handler)
 
     return this

--- a/src/promise-pool.ts
+++ b/src/promise-pool.ts
@@ -32,8 +32,8 @@ export class PromisePool<T, UseCorrespondingResults = false> {
    */
   private readonly onTaskFinishedHandlers: Array<OnProgressCallback<T>>
 
-  public static readonly notRun: Symbol = Symbol('notRun')
-  public static readonly rejected: Symbol = Symbol('rejected')
+  public static readonly notRun: symbol = Symbol('notRun')
+  public static readonly rejected: symbol = Symbol('rejected')
 
   /**
    * Instantiates a new promise pool with a default `concurrency: 10` and `items: []`.
@@ -156,7 +156,7 @@ export class PromisePool<T, UseCorrespondingResults = false> {
   async process<Result, ErrorType = any> (callback: ProcessHandler<T, Result>): Promise<
   ReturnValue<T,
   UseCorrespondingResults extends true
-    ? Result | Symbol
+    ? Result | symbol
     : Result,
   ErrorType>
   > {

--- a/src/promise-pool.ts
+++ b/src/promise-pool.ts
@@ -1,7 +1,7 @@
 'use strict'
 
 import { ReturnValue } from './return-value'
-import { PromisePoolExecutor } from './promise-pool-executor'
+import { PromisePoolExecutor, CorrespondingResult } from './promise-pool-executor'
 import { ErrorHandler, ProcessHandler, OnProgressCallback } from './contracts'
 
 export class PromisePool<T, UseCorrespondingResults = false> {
@@ -31,9 +31,6 @@ export class PromisePool<T, UseCorrespondingResults = false> {
    * The `taskFinished` handler callback functions
    */
   private readonly onTaskFinishedHandlers: Array<OnProgressCallback<T>>
-
-  public static readonly notRun: symbol = Symbol('notRun')
-  public static readonly rejected: symbol = Symbol('rejected')
 
   /**
    * Instantiates a new promise pool with a default `concurrency: 10` and `items: []`.
@@ -153,11 +150,11 @@ export class PromisePool<T, UseCorrespondingResults = false> {
    *
    * @returns Promise<{ results, errors }>
    */
-  async process<Result, ErrorType = any> (callback: ProcessHandler<T, Result>): Promise<
+  async process<R, ErrorType = any> (callback: ProcessHandler<T, R>): Promise<
   ReturnValue<T,
   UseCorrespondingResults extends true
-    ? Result | symbol
-    : Result,
+    ? CorrespondingResult<R>
+    : R,
   ErrorType>
   > {
     return new PromisePoolExecutor<T, any>()

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -2,7 +2,8 @@
 
 const { test } = require('uvu')
 const { expect } = require('expect')
-const { PromisePool, ValidationError } = require('../dist')
+const { PromisePool, ValidationError, notRun, rejected } = require('../dist')
+console.log('notRun', notRun)
 
 async function pause (timeout) {
   return new Promise(resolve => {
@@ -554,7 +555,7 @@ test('useCorrespondingResults keeps results in order', async () => {
       throw new Error('did not work')
     })
 
-  expect(results).toEqual([20, PromisePool.rejected, 10])
+  expect(results).toEqual([20, rejected, 10])
 })
 
 test('useCorrespondingResults defaults results to notRun symbol', async () => {
@@ -575,7 +576,7 @@ test('useCorrespondingResults defaults results to notRun symbol', async () => {
       throw new Error('did not work')
     })
 
-  expect(results).toEqual([20, PromisePool.rejected, 10, PromisePool.notRun])
+  expect(results).toEqual([20, rejected, 10, notRun])
 })
 
 test.run()


### PR DESCRIPTION
Following up from #58

From commit messages:

* Allow useCorrespondingResults() to be chained anywhere instead of necessitating it be last
* Use lowercase symbol type, not Symbol
* Capture unique symbols in CorrespondingResult type