### PR TITLE
Fix pool.stop() only stops after processing 1 additional item

### DIFF
--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -381,11 +381,12 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
    */
   async process (): Promise<ReturnValue<T, R>> {
     for (const [index, item] of this.items().entries()) {
+      await this.waitForProcessingSlot()
+
       if (this.isStopped()) {
         break
       }
 
-      await this.waitForProcessingSlot()
       this.startProcessing(item, index)
     }
 

--- a/test/stop-the-pool.js
+++ b/test/stop-the-pool.js
@@ -83,4 +83,24 @@ test('stops the pool from async error handler', async () => {
   expect(results).toEqual([30])
 })
 
+test('stops the pool without processing additional items', async () => {
+  const timeouts = [10, 20, 10, 20, 10, 20, 10, 20]
+
+  const { results } = await PromisePool
+    .for(timeouts)
+    .withConcurrency(2)
+    .handleError(async (_, __, pool) => {
+      pool.stop()
+    })
+    .process(async (timeout, index) => {
+      const num = index + 1
+      if (num === 5) throw new Error('stop the pool')
+
+      await pause(timeout)
+      return timeout
+    })
+
+  expect(results).toEqual([10, 20, 10, 20])
+})
+
 test.run()


### PR DESCRIPTION
I believe I have fixed the issue #63 where in some instances the pool would not stop without first processing an additional item.