### PR TITLE
Accept iterables and async iterables

### DIFF
--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -59,3 +59,5 @@ export type ErrorHandler<T> = (error: Error, item: T, pool: Stoppable & UsesConc
 export type ProcessHandler<T, R> = (item: T, index: number, pool: Stoppable & UsesConcurrency) => Promise<R> | R
 
 export type OnProgressCallback<T> = (item: T, pool: Stoppable & Statistics<T> & UsesConcurrency) => void
+
+export type SomeIterable<T> = T[] | Iterable<T> | AsyncIterable<T>

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -475,6 +475,10 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
       this.startProcessing(item, index)
 
       index += 1
+
+      // don't consume the next item from iterable
+      // until there's a free slot for a new task
+      await this.waitForProcessingSlot()
     }
 
     return await this.drained()

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -408,8 +408,8 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
       throw ValidationError.createFrom(`"timeout" must be undefined or a number. A number must be 0 or up. Received "${String(timeout)}" (${typeof timeout})`)
     }
 
-    if (!Array.isArray(this.items())) {
-      throw ValidationError.createFrom(`"items" must be an array. Received "${typeof this.items()}"`)
+    if (!this.areItemsValid()) {
+      throw ValidationError.createFrom(`"items" must be an array, an iterable or an async iterable. Received "${typeof this.items()}"`)
     }
 
     if (this.errorHandler && typeof this.errorHandler !== 'function') {
@@ -429,6 +429,14 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
     })
 
     return this
+  }
+
+  private areItemsValid (): boolean {
+    const items = this.items() as any
+    if (Array.isArray(items)) return true
+    if (typeof items[Symbol.iterator] === 'function') return true
+    if (typeof items[Symbol.asyncIterator] === 'function') return true
+    return false
   }
 
   /**

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -468,7 +468,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
       }
 
       if (this.shouldUseCorrespondingResults()) {
-        this.results()[index] = PromisePool.notRun;
+        this.results()[index] = PromisePool.notRun
       }
 
       await this.waitForProcessingSlot()

--- a/src/promise-pool.ts
+++ b/src/promise-pool.ts
@@ -2,13 +2,13 @@
 
 import { ReturnValue } from './return-value'
 import { PromisePoolExecutor } from './promise-pool-executor'
-import { ErrorHandler, ProcessHandler, OnProgressCallback } from './contracts'
+import { ErrorHandler, ProcessHandler, OnProgressCallback, SomeIterable } from './contracts'
 
 export class PromisePool<T, ShouldUseCorrespondingResults extends boolean = false> {
   /**
    * The processable items.
    */
-  private readonly items: T[]
+  private readonly items: SomeIterable<T>
 
   /**
    * The number of promises running concurrently.
@@ -50,11 +50,11 @@ export class PromisePool<T, ShouldUseCorrespondingResults extends boolean = fals
    *
    * @param {Object} options
    */
-  constructor (items?: T[]) {
+  constructor (items?: SomeIterable<T>) {
     this.timeout = undefined
     this.concurrency = 10
     this.shouldResultsCorrespond = false
-    this.items = items ?? []
+    this.items = items ?? [] as any
     this.errorHandler = undefined
     this.onTaskStartedHandlers = []
     this.onTaskFinishedHandlers = []
@@ -111,11 +111,11 @@ export class PromisePool<T, ShouldUseCorrespondingResults extends boolean = fals
   /**
    * Set the items to be processed in the promise pool.
    *
-   * @param {T[]} items
+   * @param {T[] | Iterable<T> | AsyncIterable<T>} items
    *
    * @returns {PromisePool}
    */
-  for<T> (items: T[]): PromisePool<T> {
+  for<T> (items: SomeIterable<T>): PromisePool<T> {
     return typeof this.timeout === 'number'
       ? new PromisePool<T>(items).withConcurrency(this.concurrency).withTaskTimeout(this.timeout)
       : new PromisePool<T>(items).withConcurrency(this.concurrency)
@@ -124,11 +124,11 @@ export class PromisePool<T, ShouldUseCorrespondingResults extends boolean = fals
   /**
    * Set the items to be processed in the promise pool.
    *
-   * @param {T[]} items
+   * @param {T[] | Iterable<T> | AsyncIterable<T>} items
    *
    * @returns {PromisePool}
    */
-  static for<T> (items: T[]): PromisePool<T> {
+  static for<T> (items: SomeIterable<T>): PromisePool<T> {
     return new this<T>().for(items)
   }
 

--- a/test/pool-from-iterable.js
+++ b/test/pool-from-iterable.js
@@ -41,19 +41,13 @@ test('iterates lazily', async () => {
       return item
     })
 
-  // The current implementation always fetches one more
-  // item than it needs. This has both advantages (the next
-  // task can start right away, without waiting for the next
-  // async item to be yielded, plus it's easier to implement)
-  // and disadvantages (it's slightly more wasteful on the
-  // iterable side).
   expect(logs).toEqual([
     'yielding 10',
     'yielding 20',
-    'yielding 30',
     'processed 10',
-    'yielding 40',
+    'yielding 30',
     'processed 20',
+    'yielding 40',
     'processed 30',
     'processed 40'
   ])

--- a/test/pool-from-iterable.js
+++ b/test/pool-from-iterable.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const { test } = require('uvu')
+const { expect } = require('expect')
+const { PromisePool } = require('../dist')
+
+const pause = timeout => new Promise(resolve => setTimeout(resolve, timeout))
+
+test('supports iterable in the static .for method', async () => {
+  const { results } = await PromisePool
+    .for('hello')
+    .withConcurrency(2)
+    .process(async (letter) => {
+      await pause(10)
+      return letter.toUpperCase()
+    })
+
+  expect(results.sort()).toEqual([...'EHLLO'])
+})
+
+test('iterates lazily', async () => {
+  const items = [10, 20, 30, 40]
+  const logs = []
+
+  const iterable = {
+    *[Symbol.iterator]() {
+      while (items.length > 0) {
+        const item = items.shift()
+        logs.push(`yielding ${item}`)
+        yield item
+      }
+    }
+  }
+
+  await PromisePool
+    .for(iterable)
+    .withConcurrency(2)
+    .process(async (item, index) => {
+      await pause(10 * index)
+      logs.push(`processed ${item}`)
+      return item
+    })
+
+  // The current implementation always fetches one more
+  // item than it needs. This has both advantages (the next
+  // task can start right away, without waiting for the next
+  // async item to be yielded, plus it's easier to implement)
+  // and disadvantages (it's slightly more wasteful on the
+  // iterable side).
+  expect(logs).toEqual([
+    'yielding 10',
+    'yielding 20',
+    'yielding 30',
+    'processed 10',
+    'yielding 40',
+    'processed 20',
+    'processed 30',
+    'processed 40'
+  ])
+})

--- a/test/pool-from-iterable.js
+++ b/test/pool-from-iterable.js
@@ -52,3 +52,5 @@ test('iterates lazily', async () => {
     'processed 40'
   ])
 })
+
+test.run()

--- a/test/pool-from-iterable.js
+++ b/test/pool-from-iterable.js
@@ -6,6 +6,32 @@ const { PromisePool } = require('../dist')
 
 const pause = timeout => new Promise(resolve => setTimeout(resolve, timeout))
 
+const fakeClock = {
+  time: 0,
+  schedule: [],
+  pause: (t) => new Promise(res => {
+    fakeClock.schedule.push([fakeClock.time + t, res])
+  }),
+  run: async () => {
+    await pause(0)
+    const s = fakeClock.schedule
+    if (s.length === 0) return
+
+    fakeClock.time += 1
+    for (let i = 0; i < s.length;) {
+      const [t, res] = s[i]
+      if (t <= fakeClock.time) {
+        res()
+        s.splice(i, 1)
+      } else {
+        i += 1
+      }
+    }
+
+    return fakeClock.run()
+  }
+}
+
 test('supports iterable in the static .for method', async () => {
   const { results } = await PromisePool
     .for('hello')
@@ -24,15 +50,14 @@ test('iterates lazily', async () => {
 
   const iterable = {
     *[Symbol.iterator]() {
-      while (items.length > 0) {
-        const item = items.shift()
-        logs.push(`yielding ${item}`)
+      for (const item of items) {
+        logs.push(`yielded ${item}`)
         yield item
       }
     }
   }
 
-  await PromisePool
+  const { results } = await PromisePool
     .for(iterable)
     .withConcurrency(2)
     .process(async (item, index) => {
@@ -42,14 +67,147 @@ test('iterates lazily', async () => {
     })
 
   expect(logs).toEqual([
-    'yielding 10',
-    'yielding 20',
+    'yielded 10',
+    'yielded 20',
     'processed 10',
-    'yielding 30',
+    'yielded 30',
     'processed 20',
-    'yielding 40',
+    'yielded 40',
     'processed 30',
     'processed 40'
+  ])
+
+  expect(results).toEqual([10, 20, 30, 40])
+})
+
+test('supports async iterable in the static .for method', async () => {
+  const items = [[10, 500], [20, 20], [30, 10], [40, 0]]
+  const logs = []
+
+  const iterable = {
+    async *[Symbol.asyncIterator]() {
+      for (const item of items) {
+        logs.push(`loaded ${item.join(',')}`)
+        await pause(item[0])
+
+        logs.push(`yielded ${item.join(',')}`)
+        yield item
+      }
+    }
+  }
+
+  const { results } = await PromisePool
+    .for(iterable)
+    .withConcurrency(2)
+    .process(async (item) => {
+      await pause(item[1])
+      logs.push(`processed ${item.join(',')}`)
+      return item[0]
+    })
+
+  expect(logs).toEqual([
+    'loaded 10,500',
+    'yielded 10,500',
+    'loaded 20,20',
+    'yielded 20,20',
+    'processed 20,20',
+    'loaded 30,10',
+    'yielded 30,10',
+    'processed 30,10',
+    'loaded 40,0',
+    'yielded 40,0',
+    'processed 40,0',
+    'processed 10,500',
+  ])
+
+  expect(results).toEqual([20, 30, 40, 10])
+})
+
+// The following test transitions from a badly parallelizable case, where the bottleneck
+// is the async iterator that generates the data sequentially, to a highly parallelizable
+// case where the async iterable only takes a small fraction of the overall "computation".
+//
+// The processes should be scheduled according to the following diagram,
+// where each "S" is a unit of time spent on the sequential computation (in the async iterable),
+// and each "P" is a unit of time spent on a parallelized task (in the process method):
+//
+// time:   v0        v10       v20       v30       v40
+//         SSSSSSSSSSPPPPPPPPPP    SSSSPPPPPPPSPPPP
+//                   SSSSSSSSPPPPPPPPP SSPPPPPPSPPP
+//                           SSSSSSPPPPPPPPSPPPPPSPP
+//
+// loaded: 1         2       3     4   5   6  78 9
+// yielded:          1       2     3   4 5  6  78 9
+// processed:                  1      2    3  45 6 (78 at once, then 9)
+//         ^0        ^10       ^20       ^30       ^40
+//
+// Because there are so many steps in the test, the entropy from setTimeout would quickly
+// add up, resulting in unreliable test results. Therefore we will be using a fake clock
+// which ensures that things will happen in the right order – that is, things which are
+// scheduled to happen after, say, 70ms will hapen before things which are scheduled to
+// happen after 71ms. However, the actual time that elapses between these operations is
+// completely arbitrary. 
+
+test('schedules async iterables efficiently', async () => {
+  const logs = []
+
+  async function* generateIterable() {
+    let index = 0
+    let sequentialWait = 10
+    let parallelWait = 10
+
+    while (parallelWait > 1) {
+      logs.push(`loaded ${index+1} at ${fakeClock.time}`)
+      await fakeClock.pause(sequentialWait)
+
+      logs.push(`yielded ${index+1} at ${fakeClock.time}`)
+      yield parallelWait
+
+      sequentialWait -= 2
+      sequentialWait = Math.max(sequentialWait, 1)
+      parallelWait -= 1
+      index += 1
+    }
+  }
+
+  PromisePool
+    .for(generateIterable())
+    .withConcurrency(3)
+    .process(async (timeout, index) => {
+      await fakeClock.pause(timeout)
+      logs.push(`processed ${index+1} at ${fakeClock.time}`)
+    })
+
+  await fakeClock.run()
+
+  expect(logs).toEqual([
+    'loaded 1 at 0',
+    'yielded 1 at 10',
+    'loaded 2 at 10',
+    'yielded 2 at 18',
+    'loaded 3 at 18',
+    'processed 1 at 20',
+    'yielded 3 at 24',
+    'loaded 4 at 24',
+    'processed 2 at 27',
+    'yielded 4 at 28',
+    'loaded 5 at 28',
+    'yielded 5 at 30',
+    'processed 3 at 32',
+    'loaded 6 at 32',
+    'yielded 6 at 33',
+    'processed 4 at 35',
+    'loaded 7 at 35',
+    'processed 5 at 36',
+    'yielded 7 at 36',
+    'loaded 8 at 36',
+    'yielded 8 at 37',
+    'processed 6 at 38',
+    'loaded 9 at 38',
+    'yielded 9 at 39',
+    'processed 7 at 40',
+    'processed 8 at 40',
+    'processed 9 at 41',
   ])
 })
 

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -78,7 +78,7 @@ test('ensures the items are an array', async () => {
   const pool = new PromisePool()
   const fn = () => {}
 
-  await expect(pool.for('non-array').process(fn)).rejects.toThrow(ValidationError)
+  await expect(pool.for(42).process(fn)).rejects.toThrow(ValidationError)
   await expect(await pool.for([]).process(fn)).toEqual({ errors: [], results: [] })
 })
 

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -616,7 +616,12 @@ test('useCorrespondingResults defaults results to notRun symbol', async () => {
       throw new Error('did not work')
     })
 
-  expect(results).toEqual([20, PromisePool.failed, 10, PromisePool.notRun])
+  expect(results).toEqual([
+    20,
+    PromisePool.failed,
+    PromisePool.notRun,
+    PromisePool.notRun,
+  ])
 })
 
 test('can timeout long-running handlers', async () => {

--- a/test/stop-the-pool.js
+++ b/test/stop-the-pool.js
@@ -115,23 +115,25 @@ test('stops on time with timed stop call', async () => {
   const timeouts = [100, 200, 300]
   let processedSecond = false
 
-  try {
-    await PromisePool
-      .withConcurrency(1)
-      .for(timeouts)
-      .process(async (timeout, _, pool) => {
-        // simulate user stopping pool after 50ms
-        pause(50).then(() => pool.stop()).catch(() => void 0)
+  const { results } = await PromisePool
+    .withConcurrency(1)
+    .for(timeouts)
+    .process(async (timeout, _, pool) => {
+      // simulate user stopping pool after 50ms
+      pause(50).then(() => pool.stop()).catch(() => void 0)
 
-        if (timeout === 200) {
-          processedSecond = true
-        }
-        // simulate load
-        await pause(timeout)
-        return timeout
-      })
-  } catch (_) {}
+      if (timeout === 200) {
+        processedSecond = true
+      }
+      // simulate load
+      await pause(timeout)
+      return timeout
+    })
   
+  // should only have finished the current task
+  expect(results).toEqual([100])
+
+  // should not have started the second task
   expect(processedSecond).toEqual(false)
 })
 

--- a/test/stop-the-pool.js
+++ b/test/stop-the-pool.js
@@ -80,7 +80,7 @@ test('stops the pool from async error handler', async () => {
       return timeout
     })
 
-  expect(results).toEqual([30])
+  expect(results).toEqual([])
 })
 
 test.run()


### PR DESCRIPTION
Fixes #63, fixes #71. Task list:

 * [x] Implement the functionality
 * [x] Assure existing tests pass
 * [x] Add new tests
 * [ ] Add documentation
 
**NOTE:** This PR changes the return type of `pool.items()` from the narrower type `T[]` to the wider type `T[] | Iterable<T> | AsyncIterable<T>`, which might be a :warning: **breaking change** :warning: for some TypeScript codebases!