### PR TITLE
Handle environments where Error.captureStackTrace is not defined

### DIFF
--- a/src/promise-pool-error.ts
+++ b/src/promise-pool-error.ts
@@ -25,7 +25,9 @@ export class PromisePoolError<T, E = any> extends Error {
     this.name = this.constructor.name
     this.message = this.messageFrom(error)
 
-    Error.captureStackTrace(this, this.constructor)
+    if (Error.captureStackTrace && typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor)
+    }
   }
 
   /**

--- a/src/validation-error.ts
+++ b/src/validation-error.ts
@@ -9,7 +9,9 @@ export class ValidationError extends Error {
   constructor (message?: string) {
     super(message)
 
-    Error.captureStackTrace(this, this.constructor)
+    if (Error.captureStackTrace && typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor)
+    }
   }
 
   /**

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -379,7 +379,7 @@ test('fails with string', async () => {
   ).toBe(true)
 })
 
-test('fails with Error and stacktrace', async () => {
+test('fails with Error', async () => {
   const ids = [1, 2, 3]
 
   const { errors } = await PromisePool


### PR DESCRIPTION
This change improves compatibility with non-node environments (i.e. browser) by adding a runtime check before calling `Error.captureStackTrace`.

closes: #74