### PR TITLE
fix: Clear the timer for task timeout after the task has completed

### DIFF
--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -630,19 +630,20 @@ test('useCorrespondingResults defaults results to notRun symbol', async () => {
 
 test('can timeout long-running handlers', async () => {
   const timers = [1, 2, 3, 4]
+  const leeway = 5
 
   const { results, errors } = await PromisePool
     .withTaskTimeout(10)
     .for(timers)
     .process(async (timer) => {
-      const computed = 10 * timer
+      const computed = 10 * timer - leeway
       await pause(computed)
 
       return computed
     })
 
   // only the first item resolves
-  expect(results).toEqual([10])
+  expect(results).toEqual([5])
 
   // items 2, 3, and 4 time out
   expect(errors.length).toEqual(3)


### PR DESCRIPTION
The timer for task timeout is not cleared with clearTimeout, causing it to persist in the event loop even after the task has finished processing. As a result, the Node.js process cannot terminate until the time specified for the timer has elapsed. The issue can be replicated using the following code:

```
 await PromisePool.for([...Array(100).keys()])
    .withConcurrency(100)
    .withTaskTimeout(180 * 1000)
    .process(async (key, _index, _pool) => {
      return key
    })

const info = process.getActiveResourcesInfo()
console.log({ info })
```