### PR TITLE
Mark all files are sideEffects-free to make each tree-shakable

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
     "test:coverage": "c8 --include=dist npm run test:run && npm run test:report",
     "test:report": "c8 report --reporter=html"
   },
+  "sideEffects": false,
   "types": "dist"
 }


### PR DESCRIPTION
Closes #83

IIUC, `"sideEffects": false` allows bundler like Webpack and esbuild to tree-shake unused code.

As far as I checked,  all files in `src/` has no side-effect.