### PR TITLE
Stop storing processed items in memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,7 @@ await PromisePool
   .for(users)
   .onTaskStarted((item, pool) => {
     console.log(`Progress: ${pool.processedPercentage()}%`)
-    console.log(`Active tasks: ${pool.processedItems().length}`)
     console.log(`Active tasks: ${pool.activeTasksCount()}`)
-    console.log(`Finished tasks: ${pool.processedItems().length}`)
     console.log(`Finished tasks: ${pool.processedCount()}`)
   })
   .onTaskFinished((item, pool) => {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -25,7 +25,7 @@ export interface Stoppable {
   isStopped(): boolean
 }
 
-export interface Statistics<T> {
+export interface Statistics {
   /**
    * Returns the number of currently active tasks.
    *
@@ -37,11 +37,6 @@ export interface Statistics<T> {
    * Returns the number of currently active tasks.
    */
   activeTasksCount (): number
-
-  /**
-   * Returns the list of processed items.
-   */
-  processedItems (): T[]
 
   /**
    * Returns the number of processed items.
@@ -58,6 +53,6 @@ export type ErrorHandler<T> = (error: Error, item: T, pool: Stoppable & UsesConc
 
 export type ProcessHandler<T, R> = (item: T, index: number, pool: Stoppable & UsesConcurrency) => Promise<R> | R
 
-export type OnProgressCallback<T> = (item: T, pool: Stoppable & Statistics<T> & UsesConcurrency) => void
+export type OnProgressCallback<T> = (item: T, pool: Stoppable & Statistics & UsesConcurrency) => void
 
 export type SomeIterable<T> = T[] | Iterable<T> | AsyncIterable<T>

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -7,7 +7,7 @@ import { PromisePoolError } from './promise-pool-error'
 import { StopThePromisePoolError } from './stop-the-promise-pool-error'
 import { ErrorHandler, ProcessHandler, OnProgressCallback, Statistics, Stoppable, UsesConcurrency, SomeIterable } from './contracts'
 
-export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, Statistics<T> {
+export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, Statistics {
   /**
    * Stores the internal properties.
    */
@@ -18,9 +18,9 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
     items: SomeIterable<T>
 
     /**
-     * The list of processed items.
+     * The processed items counter.
      */
-    processedItems: T[]
+    processedItemsCounter: number
 
     /**
      * The number of concurrently running tasks.
@@ -91,7 +91,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
       stopped: false,
       concurrency: 10,
       shouldResultsCorrespond: false,
-      processedItems: [],
+      processedItemsCounter: 0,
       taskTimeout: 0
     }
 
@@ -208,17 +208,17 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
   }
 
   /**
-   * Returns the list of processed items.
+   * Increment the processed items counter.
    */
-  processedItems (): T[] {
-    return this.meta.processedItems
+  incrementProcessedItemsCounter (): void {
+    this.meta.processedItemsCounter++
   }
 
   /**
    * Returns the number of processed items.
    */
   processedCount (): number {
-    return this.processedItems().length
+    return this.meta.processedItemsCounter
   }
 
   /**
@@ -453,7 +453,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
         this.removeActive(task)
       })
       .finally(() => {
-        this.processedItems().push(item)
+        this.incrementProcessedItemsCounter()
         this.runOnTaskFinishedHandlers(item)
       })
 

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -503,7 +503,7 @@ test('onTaskFinished is called when a task was processed', async () => {
     .for(ids)
     .onTaskFinished((item, pool) => {
       finishedIds.push(item)
-      expect(finishedIds).toEqual(pool.processedItems())
+      expect(finishedIds.length).toEqual(pool.processedCount())
       expect(pool.activeTaskCount()).toBeLessThanOrEqual(concurrency)
       expect(pool.processedPercentage()).toEqual(percentageArr.shift())
     })


### PR DESCRIPTION
Processed items will be counted instead of storing them in a array.

Previous implementation causes excessive memory consumption when processing huge datasets.

`processedItems` field was exposed to the user e.g in `onTaskStarted` or `OnProgressCallback` through `Statistics` so this  is a braking change after all.