### PR TITLE
Allow flushing processed items array

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ await PromisePool
   })
   .onTaskFinished((item, pool) => {
     // update a progress bar or something else :)
+
+    // You can flush processed items to free up memory
+    pool.flushProcessedItems()
   })
   .process(async (user, index, pool) => {
     // processes the `user` data

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -44,6 +44,11 @@ export interface Statistics<T> {
   processedItems (): T[]
 
   /**
+   * Flush the processed items.
+   */
+  flushProcessedItems (): void
+
+  /**
    * Returns the number of processed items.
    */
   processedCount (): number

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -23,6 +23,11 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
     processedItems: T[]
 
     /**
+     * The processed items counter
+     */
+    processedItemsCounter: number
+
+    /**
      * The number of concurrently running tasks.
      */
     concurrency: number
@@ -92,6 +97,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
       concurrency: 10,
       shouldResultsCorrespond: false,
       processedItems: [],
+      processedItemsCounter: 0,
       taskTimeout: 0
     }
 
@@ -215,10 +221,24 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
   }
 
   /**
+   * Flush the processed items.
+   */
+  flushProcessedItems (): void {
+    this.meta.processedItems = []
+  }
+
+  /**
+   * Increment the processed items counter.
+   */
+  private incrementProcessedItemsCounter (): void {
+    this.meta.processedItemsCounter += 1
+  }
+
+  /**
    * Returns the number of processed items.
    */
   processedCount (): number {
-    return this.processedItems().length
+    return this.meta.processedItemsCounter
   }
 
   /**
@@ -454,6 +474,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
       })
       .finally(() => {
         this.processedItems().push(item)
+        this.incrementProcessedItemsCounter()
         this.runOnTaskFinishedHandlers(item)
       })
 

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -514,6 +514,41 @@ test('onTaskFinished is called when a task was processed', async () => {
   expect(ids).toEqual(finishedIds)
 })
 
+test('flushProcessedItems flushes the processed items', async () => {
+  const items = new Array(100).fill('foo')
+  const concurrency = 10
+
+  await PromisePool
+    .withConcurrency(concurrency)
+    .for(items)
+    .onTaskFinished((item, pool) => {
+      expect(pool.processedItems().includes(item)).toBe(true)
+      pool.flushProcessedItems()
+      expect(pool.processedItems().length).toEqual(0)
+    })
+    .process(async () => {
+      return await Promise.resolve()
+    })
+})
+
+test('flushProcessedItems doesn\'t reset the processed items counter', async () => {
+  const items = new Array(100).fill('foo')
+  const concurrency = 10
+  let i = 0
+
+  await PromisePool
+    .withConcurrency(concurrency)
+    .for(items)
+    .onTaskFinished((_, pool) => {
+      i++
+      pool.flushProcessedItems()
+      expect(pool.processedCount()).toEqual(i)
+    })
+    .process(async () => {
+      return await Promise.resolve()
+    })
+})
+
 test('onTaskStarted and onTaskFinished are called in the same amount', async () => {
   const ids = [1, 2, 3, 4, 5]
   const concurrency = 3

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -524,6 +524,7 @@ test('flushProcessedItems flushes the processed items', async () => {
     .onTaskFinished((item, pool) => {
       expect(pool.processedItems().includes(item)).toBe(true)
       pool.flushProcessedItems()
+    })
     .process(async () => {
       return await Promise.resolve()
     })
@@ -562,7 +563,7 @@ test('flushProcessedItems doesn\'t reset the processed items counter', async () 
       return await Promise.resolve()
     })
 })
-  
+
 test('processedCount works properly when dontStoreProcessedItems is used', async () => {
   const ids = Array.from({ length: 100 }, (_, i) => i + 1)
   const concurrency = 10


### PR DESCRIPTION
Allows consumer to flush processed items array once the task is finished, so that processed items won't clog the memory when running the pools over e.g big files.

This is an alternative approach to my previous PR. This will fix the problem without introducing braking changes.

