### PR TITLE
Allow disabling processed items retention

### DIFF
--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -34,6 +34,11 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
     shouldResultsCorrespond: boolean
 
     /**
+     * Determine whether to store the processed items in memory.
+     */
+    shouldStoreProcessedItems: boolean
+
+    /**
      * The maximum timeout in milliseconds for the item handler, or `undefined` to disable.
      */
     taskTimeout: number | undefined
@@ -92,7 +97,8 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
       concurrency: 10,
       shouldResultsCorrespond: false,
       processedItems: [],
-      taskTimeout: 0
+      taskTimeout: 0,
+      shouldStoreProcessedItems: true
     }
 
     this.handler = (item) => item as any
@@ -112,6 +118,21 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
     this.meta.concurrency = concurrency
 
     return this
+  }
+
+  /**
+   * Set whether to store the processed items in memory.
+   */
+  setShouldStoreProcessedItems (shouldStoreProcessedItems: boolean): this {
+    this.meta.shouldStoreProcessedItems = shouldStoreProcessedItems
+    return this
+  }
+
+  /**
+   * Determine whether to store the processed items in memory.
+   */
+  private shouldStoreProcessedItems (): boolean {
+    return this.meta.shouldStoreProcessedItems
   }
 
   /**
@@ -453,7 +474,9 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
         this.removeActive(task)
       })
       .finally(() => {
-        this.processedItems().push(item)
+        if (this.shouldStoreProcessedItems()) {
+          this.processedItems().push(item)
+        }
         this.runOnTaskFinishedHandlers(item)
       })
 

--- a/src/promise-pool-executor.ts
+++ b/src/promise-pool-executor.ts
@@ -23,6 +23,11 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
     processedItems: T[]
 
     /**
+     * The processed items counter
+     */
+    processedItemsCounter: number
+
+    /**
      * The number of concurrently running tasks.
      */
     concurrency: number
@@ -97,6 +102,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
       concurrency: 10,
       shouldResultsCorrespond: false,
       processedItems: [],
+      processedItemsCounter: 0,
       taskTimeout: 0,
       shouldStoreProcessedItems: true
     }
@@ -236,10 +242,17 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
   }
 
   /**
+   * Increment the processed items counter.
+   */
+  private incrementProcessedItemsCounter (): void {
+    this.meta.processedItemsCounter += 1
+  }
+
+  /**
    * Returns the number of processed items.
    */
   processedCount (): number {
-    return this.processedItems().length
+    return this.meta.processedItemsCounter
   }
 
   /**
@@ -477,6 +490,7 @@ export class PromisePoolExecutor<T, R> implements UsesConcurrency, Stoppable, St
         if (this.shouldStoreProcessedItems()) {
           this.processedItems().push(item)
         }
+        this.incrementProcessedItemsCounter()
         this.runOnTaskFinishedHandlers(item)
       })
 

--- a/src/promise-pool.ts
+++ b/src/promise-pool.ts
@@ -23,6 +23,11 @@ export class PromisePool<T, ShouldUseCorrespondingResults extends boolean = fals
   private shouldResultsCorrespond: boolean
 
   /**
+   * Determine whether to store the processed items in memory.
+   */
+  private shouldStoreProcessedItems: boolean = true
+
+  /**
    * The maximum timeout in milliseconds for the item handler, or `undefined` to disable.
    */
   private timeout: number | undefined
@@ -131,6 +136,14 @@ export class PromisePool<T, ShouldUseCorrespondingResults extends boolean = fals
   }
 
   /**
+   * Prevent PromisePool from storing the processed items in memory.
+   */
+  dontStoreProcessedItems (): PromisePool<T> {
+    this.shouldStoreProcessedItems = false
+    return this
+  }
+
+  /**
    * Assign the given callback `handler` function to run when a task finished.
    */
   onTaskFinished (handler: OnProgressCallback<T>): PromisePool<T> {
@@ -158,6 +171,7 @@ export class PromisePool<T, ShouldUseCorrespondingResults extends boolean = fals
     return new PromisePoolExecutor<T, ResultType>()
       .useConcurrency(this.concurrency)
       .useCorrespondingResults(this.shouldResultsCorrespond)
+      .setShouldStoreProcessedItems(this.shouldStoreProcessedItems)
       .withTaskTimeout(this.timeout)
       .withHandler(callback)
       .handleError(this.errorHandler)

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -514,6 +514,40 @@ test('onTaskFinished is called when a task was processed', async () => {
   expect(ids).toEqual(finishedIds)
 })
 
+test('dontStoreProcessedItems prevents storing processed items in memory', async () => {
+  const ids = Array.from({ length: 30 }, (_, i) => i + 1)
+  const concurrency = 3
+
+  await PromisePool
+    .withConcurrency(concurrency)
+    .for(ids)
+    .dontStoreProcessedItems()
+    .onTaskFinished((_, pool) => {
+      expect(pool.processedItems().length).toEqual(0)
+    })
+    .process(async () => {
+      return await Promise.resolve()
+    })
+})
+
+test('processedCount works properly when dontStoreProcessedItems is used', async () => {
+  const ids = Array.from({ length: 100 }, (_, i) => i + 1)
+  const concurrency = 10
+  let counter = 0
+
+  await PromisePool
+    .withConcurrency(concurrency)
+    .for(ids)
+    .dontStoreProcessedItems()
+    .onTaskFinished((_, pool) => {
+      counter++
+      expect(pool.processedCount()).toEqual(counter)
+    })
+    .process(async () => {
+      return await Promise.resolve()
+    })
+})
+
 test('onTaskStarted and onTaskFinished are called in the same amount', async () => {
   const ids = [1, 2, 3, 4, 5]
   const concurrency = 3

--- a/test/promise-pool.js
+++ b/test/promise-pool.js
@@ -573,25 +573,25 @@ test('onTaskStarted and onTaskFinished are called in the same amount', async () 
 
 test('can decrease the concurrency while the pool is running', async () => {
   const concurrency = 3
-  const timeouts = [10, 20, 30, 40, 50]
+  const timeouts = [100, 100, 100, 100, 100, 100, 100, 100]
+  const expectedNumParallelProcessesPerLoop = [1, 2, 3, 3, 3, 1, 1, 1]
+  const measuredNumParallelProcessesPerLoop = []
 
-  const start = Date.now()
-
+  let numInProgress = 0
   await PromisePool
     .withConcurrency(concurrency)
     .for(timeouts)
-    .process(async (timeout, _, pool) => {
-      if (timeout >= 30) {
+    .process(async (timeout, i, pool) => {
+      numInProgress++
+      measuredNumParallelProcessesPerLoop[i] = numInProgress
+      if (i === 4) {
         pool.useConcurrency(1)
       }
-
       await pause(timeout)
+      numInProgress--
     })
 
-  const elapsed = Date.now() - start
-
-  expect(elapsed).toBeGreaterThanOrEqual(30 + 40 + 50)
-  expect(elapsed).toBeLessThanOrEqual(30 + 40 + 50 + 8) // +8 is a leeway for the pool overhead
+  expect(expectedNumParallelProcessesPerLoop).toEqual(measuredNumParallelProcessesPerLoop)
 })
 
 test('can increase the concurrency while the pool is running', async () => {


### PR DESCRIPTION
This MR introduces `dontStoreProcessedItems` method to `PromisePool`, allowing caller to disable retention of processed items in memory.